### PR TITLE
add last_hope_attempts_backoff option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Key | Required | Type | Description
 **callback_emails** | `false` | `String` | The email addresses diawi will send the result to (up to 5 separated by commas for starter/premium/enterprise accounts, 1 for free accounts). Emails should be a string. Ex: "example@test.com,example1@test.com"
 **installation_notifications** | `false` | `Boolean` | Receive notifications each time someone installs the app (only starter/premium/enterprise accounts)
 **last_hope_attempts_count**⁺ | `false` | `Int` | Number of extra attempts to check file status (default: 1, max: 5, not in range (1...5): 1)
+**last_hope_attempts_backoff**⁺ | `false` | `Int` | Number of seconds to wait between repeated attempts at checking upload status. Default - 2
 
 <details><summary>⁺ Explanation</summary><p>
     

--- a/lib/fastlane/plugin/diawi/actions/diawi_action.rb
+++ b/lib/fastlane/plugin/diawi/actions/diawi_action.rb
@@ -58,14 +58,14 @@ module Fastlane
                 job = JSON.parse(response.body)['job']
 
                 if job
-                    return self.check_status(options[:token], options[:file], job, options[:last_hope_attempts_count])
+                    return self.check_status(options[:token], options[:file], job, options[:last_hope_attempts_count], options[:last_hope_attempts_backoff])
                 end
 
                 UI.important("Something went wrong and `job` value didn't come from uploading request. Check out your dashboard: https://dashboard.diawi.com/. Maybe your file already has been uploaded successfully.")
                 UI.important("If not, try to upload file by yourself. Path: #{options[:file]}")
             end
 
-            def self.check_status(token, file, job, last_hope_attempts_count)
+            def self.check_status(token, file, job, last_hope_attempts_count, last_hope_attempts_backoff)
                 # From documendation:
 
                 # Polling frequence
@@ -130,7 +130,7 @@ module Fastlane
                     end
 
                     polling_attempts += 1
-                    sleep(2)
+                    sleep(last_hope_attempts_backoff)
                 end
 
                 UI.important("File is not processed.")
@@ -198,7 +198,13 @@ module Fastlane
                                          description: "Number of attempts to check status after last attempt. Default - 1, max - 5. (See more at `self.check_status` func comment)",
                                            is_string: false,
                                             optional: true,
-                                       default_value: 1)
+                                       default_value: 1),
+                    FastlaneCore::ConfigItem.new(key: :last_hope_attempts_backoff,
+                                            env_name: "DIAWI_LAST_HOPE_ATTEMPTS_BACKOFF",
+                                         description: "Number of seconds to wait between repeated attempts at checking upload status. Default - 2. (See more at `self.check_status` func comment)",
+                                           is_string: false,
+                                            optional: true,
+                                       default_value: 2)
                 ]
             end
 


### PR DESCRIPTION
This allows users to specify number of seconds the plugin will wait
before it makes another attempt at checking the upload status.

This is related to #10.
