### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin can upload .ipa and .apk file to diawi.
 
 `timeout` - new key.
 
-For more info see [2.0.0 pull request]().
+For more info see [2.0.0 pull request](https://github.com/pacification/fastlane-plugin-diawi/pull/16).
 
 ## Available options
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more info see [2.0.0 pull request]().
 Key | Required | Type | Description
 --- | --- | --- | ---
 **token** | **`true`** | `String` | [API access token](https://dashboard.diawi.com/profile/api)
-**file** | `false` | `String` | Path to .ipa or .apk file.<br>default: `IPA_OUTPUT_PATH` or `GRADLE_APK_OUTPUT_PATH` based on platform
+**file** | `false` | `String` | Path to .ipa or .apk file.<br>**Default**: `IPA_OUTPUT_PATH` or `GRADLE_APK_OUTPUT_PATH` based on platform
 **find_by_udid** | `false` | `Boolean` | Allow your testers to find the app on diawi's mobile web app using their UDID (**iOS only**)
 **wall_of_apps** | `false` | `Boolean` | Allow diawi to display the app's icon on the wall of apps
 **password** | `false` | `String` | Protect your app with a password: it will be required to access the installation page
@@ -38,8 +38,8 @@ Key | Required | Type | Description
 **callback_url** | `false` | `String` | The URL diawi should call with the result
 **callback_emails** | `false` | `String` | The email addresses diawi will send the result to (up to 5 separated by commas for starter/premium/enterprise accounts, 1 for free accounts). Emails should be a string. Ex: "example@test.com,example1@test.com"
 **installation_notifications** | `false` | `Boolean` | Receive notifications each time someone installs the app (only starter/premium/enterprise accounts)
-**timeout** | `false` | `Int` | Timeout for checking upload status in seconds.<br>default: 60<br>range: (5, 240)
-**check_status_delay** | `false` | `Int` | Number of seconds to wait between repeated attempts at checking upload status.<br>default: 3<br>range: (1, 30)
+**timeout** | `false` | `Int` | Timeout for checking upload status in seconds.<br>**Default**: 60<br>**Range**: (5, 240)
+**check_status_delay** | `false` | `Int` | Number of seconds to wait between repeated attempts at checking upload status.<br>**Default**: 3<br>**Range**: (1, 30)
 
 ## Result link
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,22 @@ fastlane add_plugin diawi
 Diawi is a tool for developers to deploy Development and In-house applications directly to the devices.
 This plugin can upload .ipa and .apk file to diawi.
 
+## Migration to 2.0.0
+
+`last_hope_attempts_count` - removed.
+
+`last_hope_attempts_backoff` - renamed to `check_status_delay`.
+
+`timeout` - new key.
+
+For more info see [2.0.0 pull request]().
+
 ## Available options
 
 Key | Required | Type | Description
 --- | --- | --- | ---
 **token** | **`true`** | `String` | [API access token](https://dashboard.diawi.com/profile/api)
-**file** | `false` | `String` | Path to .ipa or .apk file. Default - `IPA_OUTPUT_PATH` or `GRADLE_APK_OUTPUT_PATH` based on platform
+**file** | `false` | `String` | Path to .ipa or .apk file.<br>default: `IPA_OUTPUT_PATH` or `GRADLE_APK_OUTPUT_PATH` based on platform
 **find_by_udid** | `false` | `Boolean` | Allow your testers to find the app on diawi's mobile web app using their UDID (**iOS only**)
 **wall_of_apps** | `false` | `Boolean` | Allow diawi to display the app's icon on the wall of apps
 **password** | `false` | `String` | Protect your app with a password: it will be required to access the installation page
@@ -28,32 +38,8 @@ Key | Required | Type | Description
 **callback_url** | `false` | `String` | The URL diawi should call with the result
 **callback_emails** | `false` | `String` | The email addresses diawi will send the result to (up to 5 separated by commas for starter/premium/enterprise accounts, 1 for free accounts). Emails should be a string. Ex: "example@test.com,example1@test.com"
 **installation_notifications** | `false` | `Boolean` | Receive notifications each time someone installs the app (only starter/premium/enterprise accounts)
-**last_hope_attempts_count**⁺ | `false` | `Int` | Number of extra attempts to check file status (default: 1, max: 5, not in range (1...5): 1)
-**last_hope_attempts_backoff**⁺ | `false` | `Int` | Number of seconds to wait between repeated attempts at checking upload status. Default - 2
-
-<details><summary>⁺ Explanation</summary><p>
-    
-From [diawi's documentation](https://dashboard.diawi.com/docs/apis/upload):
-
-> Polling frequence  
-> If possible, prefer using the callbacks than the polling: they will always provide you with the result as soon as it is available.
->
-> Usually, processing of an upload will take a few seconds: so, a base rule would be to poll every 2 seconds for up to 5 times and should match most simple use-cases.
->
-> For larger apps, a longer processing might be needed on our side. A rule of thumb would be to wait up to 1 second for each 10 MB of the app. In other words, up to 10 seconds for a 100 MB app, 50 seconds for a 500 MB app, and so on…
->
-> If the status is still 2001 after that duration, there probably is a problem, let us know.
-
-Technically your app can be uploaded to diawi, but still processing for a while. In this case `last_hope_attempts_count` can add extra `n` check status requests.
-
-Example:  
-```ruby
-last_hope_attempts_count = 3  
-app_size = 23 MB  
-check_attempts = 23 / 10 + last_hope_attempts_count = 5 # total attempts is 5; but it will return at first success response
-```
-    
-</p></details>
+**timeout** | `false` | `Int` | Timeout for checking upload status in seconds.<br>default: 60<br>range: (5, 240)
+**check_status_delay** | `false` | `Int` | Number of seconds to wait between repeated attempts at checking upload status.<br>default: 3<br>range: (1, 30)
 
 ## Result link
 

--- a/lib/fastlane/plugin/diawi/actions/diawi_action.rb
+++ b/lib/fastlane/plugin/diawi/actions/diawi_action.rb
@@ -91,6 +91,7 @@ module Fastlane
                         UI.important("Check file status request error:")
                         UI.important(error)
                         sleep(check_status_delay)
+                        current_time = Time.now
                         next
                     end
 
@@ -114,6 +115,7 @@ module Fastlane
                     end
 
                     sleep(check_status_delay)
+                    current_time = Time.now
                 end
 
                 UI.important("File is not processed.")

--- a/lib/fastlane/plugin/diawi/actions/diawi_action.rb
+++ b/lib/fastlane/plugin/diawi/actions/diawi_action.rb
@@ -178,7 +178,7 @@ module Fastlane
                                             optional: true),
                     FastlaneCore::ConfigItem.new(key: :timeout,
                                             env_name: "DIAWI_TIMEOUT",
-                                         description: "Timeout for cheching upload status in seconds. Default: 60, range: (5, 240)",
+                                         description: "Timeout for checking upload status in seconds. Default: 60, range: (5, 240)",
                                            is_string: false,
                                             optional: true,
                                        default_value: 60),

--- a/lib/fastlane/plugin/diawi/actions/diawi_action.rb
+++ b/lib/fastlane/plugin/diawi/actions/diawi_action.rb
@@ -56,49 +56,33 @@ module Fastlane
                 end
 
                 job = JSON.parse(response.body)['job']
-                UI.success("Upload success. Processing started, job=#{job} Please, be patient. This could take some time.")
                 
                 if job
-                    return self.check_status(options[:token], options[:file], job, options[:last_hope_attempts_count], options[:last_hope_attempts_backoff])
+                    timeout = options[:timeout].clamp(5, 240)
+                    check_status_delay = options[:check_status_delay].clamp(1, 30)
+
+                    if check_status_delay > timeout
+                        UI.important("`check_status_delay` is greater than `timeout`")
+                    end
+
+                    UI.success("Upload completed successfully.")
+                    UI.success("\n\nProcessing started with params:\n\njob: #{job}\ntimeout: #{timeout},\ncheck_status_delay: #{check_status_delay}\n")
+                    return self.check_status(options[:token], options[:file], job, options[:timeout], options[:check_status_delay])
                 end
 
                 UI.important("Something went wrong and `job` value didn't come from uploading request. Check out your dashboard: https://dashboard.diawi.com/. Maybe your file already has been uploaded successfully.")
                 UI.important("If not, try to upload file by yourself. Path: #{options[:file]}")
             end
 
-            def self.check_status(token, file, job, last_hope_attempts_count, last_hope_attempts_backoff)
-                # From documendation:
-
-                # Polling frequence
-                # Usually, processing of an upload will take a few seconds:
-                # so, a base rule would be to poll every 2 seconds for up to 5 times and should match most simple use-cases.
-
-                # For larger apps, a longer processing might be needed on our side.
-                # A rule of thumb would be to wait up to 1 second for each 10 MB of the app.
-                # In other words, up to 10 seconds for a 100 MB app, 50 seconds for a 500 MB app, and so on…
-
-                # ^ Based on this here we calculate polling_count
-
-                file_size = (File.size(file).to_i) / 2**20
-                additional_polling_count = last_hope_attempts_count.between?(1, 5) ? last_hope_attempts_count : 1
-                polling_count = file_size / 10 + additional_polling_count # also add "last hope" attempts
-
-                polling_attempts = 0
-
+            def self.check_status(token, file, job, timeout, check_status_delay)
                 status_ok = 2000
                 status_in_progress = 2001
                 status_error = 4000
 
-                # According to:
-                #
-                # "processing of an upload will take a few seconds: a base rule would be to poll every 2 seconds".
-                #
-                # here introduced sleep 2 seconds before first check requst.
-                # it should solve the problem with check status of small file size (> 10 mb).
-                # if you need more attempts, use `DIAWI_LAST_HOPE_ATTEMPTS_COUNT`.
-                sleep(2)
+                timeout_time = Time.now + timeout
+                current_time = Time.now
 
-                while polling_count > polling_attempts  do
+                while timeout_time > current_time  do
                     response = RestClient.get STATUS_CHECK_URL, {params: {token: token, job: job}}
 
                     begin
@@ -106,8 +90,7 @@ module Fastlane
                     rescue RestClient::ExceptionWithResponse => error
                         UI.important("Check file status request error:")
                         UI.important(error)
-                        polling_attempts += 1
-                        sleep(2)
+                        sleep(check_status_delay)
                         next
                     end
 
@@ -130,8 +113,7 @@ module Fastlane
                         UI.important("Unknown error uploading file to diawi.")
                     end
 
-                    polling_attempts += 1
-                    sleep(last_hope_attempts_backoff)
+                    sleep(check_status_delay)
                 end
 
                 UI.important("File is not processed.")
@@ -194,18 +176,18 @@ module Fastlane
                                          description: "Receive notifications each time someone installs the app (only starter/premium/enterprise accounts)",
                                            is_string: false,
                                             optional: true),
-                    FastlaneCore::ConfigItem.new(key: :last_hope_attempts_count,
-                                            env_name: "DIAWI_LAST_HOPE_ATTEMPTS_COUNT",
-                                         description: "Number of attempts to check status after last attempt. Default - 1, max - 5. (See more at `self.check_status` func comment)",
+                    FastlaneCore::ConfigItem.new(key: :timeout,
+                                            env_name: "DIAWI_TIMEOUT",
+                                         description: "Timeout for cheching upload status in seconds. Default: 60, range: (5, 240)",
                                            is_string: false,
                                             optional: true,
-                                       default_value: 1),
-                    FastlaneCore::ConfigItem.new(key: :last_hope_attempts_backoff,
-                                            env_name: "DIAWI_LAST_HOPE_ATTEMPTS_BACKOFF",
-                                         description: "Number of seconds to wait between repeated attempts at checking upload status. Default - 2. (See more at `self.check_status` func comment)",
+                                       default_value: 60),
+                    FastlaneCore::ConfigItem.new(key: :check_status_delay,
+                                            env_name: "DIAWI_CHECK_STATUS_DELAY",
+                                         description: "Number of seconds to wait between repeated attempts at checking upload status. Default: 3, range: (1, 30)",
                                            is_string: false,
                                             optional: true,
-                                       default_value: 2)
+                                       default_value: 3)
                 ]
             end
 

--- a/lib/fastlane/plugin/diawi/version.rb
+++ b/lib/fastlane/plugin/diawi/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Diawi
-    VERSION = "1.4.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
The previous way for checking upload status was like code smell. This version introduce new way to doing that.

Key | Status | Additional info
--- | --- | ---
`last_hope_attempts_count` | removed | -
`last_hope_attempts_backoff` | renamed | to `check_status_delay`
`timeout` | added | -

Now you can use `timeout` to specify timeout for checking upload status. `check_status_delay` allows you to specify the number of seconds to wait between repeated attempts at checking upload status.